### PR TITLE
Handle new node

### DIFF
--- a/app/src/actions/OutletActions.js
+++ b/app/src/actions/OutletActions.js
@@ -11,29 +11,25 @@ class OutletActions {
   }
 
   fetchOutlets() {
-  	fetch(API_OUTLETS_URL)
+  	return fetch(API_OUTLETS_URL)
       .then((response) => response.json())
       .then((responseData) => {
         this.outletsChanged(responseData);
       })
       .catch(console.error)
-      .done();
-    return [];
   }
 
   fetchOutlet(outlet_id) {
-    fetch(`${API_OUTLETS_URL}/${outlet_id}`)
+    return fetch(`${API_OUTLETS_URL}/${outlet_id}`)
       .then((response) => response.json())
       .then((responseData) => {
         this.outletChanged(responseData);
       })
       .catch(console.error)
-      .done();
-    return {};
   }
 
   updateOutletName(outlet_id, name) {
-    fetch(`${API_OUTLETS_URL}/${outlet_id}`, {
+    return fetch(`${API_OUTLETS_URL}/${outlet_id}`, {
       method: 'POST',
       headers: {
         'Accept': 'application/json',
@@ -46,8 +42,6 @@ class OutletActions {
         this.outletChanged(responseData);
       })
       .catch(console.error)
-      .done();
-    return {};
   }
 }
 

--- a/app/src/lib/Constants.js
+++ b/app/src/lib/Constants.js
@@ -1,5 +1,6 @@
-// export const API_BASE_URL = 'http://localhost:3000';
-export const API_BASE_URL = 'https://rkmanuwnat.localtunnel.me';
+export const API_BASE_URL = 'http://localhost:3000';
+// export const API_BASE_URL = 'https://rkmanuwnat.localtunnel.me';
+export const WEBSOCKET_URL = API_BASE_URL.replace('https','ws').replace('http','ws');
 export const API_OUTLETS_URL = `${API_BASE_URL}/outlets`;
 export const API_EVENTS_URL = `${API_BASE_URL}/events`;
 

--- a/server/app.js
+++ b/server/app.js
@@ -6,6 +6,7 @@ var logger           = require('morgan');
 var bodyParser       = require('body-parser');
 var outletsCtrl      = require('./controllers/Outlets');
 var eventsCtrl       = require('./controllers/Events');
+var Gateway					 = require('./gateway');
 
 var app = express();
 
@@ -41,6 +42,11 @@ app.post('/events/', eventsCtrl.createEvent);
 app.get('/events/clear', eventsCtrl.clearEvents);
 app.get('/events/:id', eventsCtrl.getEventDetails);
 app.post('/events/:id', eventsCtrl.updateEvent);
+app.get('/handlepacket/:packet', (req, res, next) => {
+	return Gateway.handleData(req.params.packet)
+		.then(result => res.json(result))
+		.catch(next);
+});
 
 // Undefined Route Handler
 // (request url doesn't match any routes)

--- a/server/gateway.js
+++ b/server/gateway.js
@@ -163,15 +163,10 @@ function handleData(data) {
 			return handleSensorDataMessage(macAddress, payload);
 		case OUTLET_ACTION_ACK_MESSAGE:
 			return handleActionAckMessage(macAddress, payload);
-<<<<<<< HEAD
 		case OUTLET_HANDSHAKE_ACK_MESSAGE:
     	return handleHandshakeAckMessage(macAddress, payload);
     case OUTLET_LOST_NODE_MESSAGE:
     	return handleLostNodeMessage(macAddress, payload);
-=======
-        case OUTLET_HANDSHAKE_ACK_MESSAGE:
-            return handleHandshakeAckMessage(macAddress, payload);
->>>>>>> aea03d8dbb0921c76efd49c63577b38fb2869349
 		default:
 			console.error(`Unknown Message type: ${msgId}`);
 			return Promise.reject(new Error(`Unknown Message type: ${msgId}`));

--- a/server/gateway.js
+++ b/server/gateway.js
@@ -99,17 +99,12 @@ function handleActionAckMessage(macAddress, payload) {
  * And send a websocket message to the app to notify the user.
  */
 function handleHandshakeAckMessage(macAddress, payload) {
-    var params = payload.split(',');
-    if (params.length < 1) {
-        throw new Error("Not enough params in Handshake Ack payload: " + payload);
-    }
-    var newMacAddress = params[0];
-    return Outlet.find({mac_address: newMacAddress}).exec()
+    return Outlet.find({mac_address: macAddress}).exec()
         .then( outlets => {
             if (outlets.length > 0) {
-                throw new Error("Handshake ack message received for existing outlet MAC address: " + newMacAddress);
+                throw new Error("Handshake ack message received for existing outlet MAC address: " + macAddress);
             }
-            var outlet = new Outlet({mac_address: newMacAddress});
+            var outlet = new Outlet({mac_address: macAddress});
             return outlet.save();
         }).then( outlet => {
             // TODO: send socket mesage to app announcing new node

--- a/server/gateway.js
+++ b/server/gateway.js
@@ -107,8 +107,8 @@ function handleData(data) {
 	// "source_mac_addr:seq_num:msg_type:num_hops:payload"
 	var components = data.split(':');
 	if (components.length !== 5) {
-		console.error("Invalid minimum packet length");
-		return;
+		console.error("Invalid packet length");
+		return Promise.reject(new Error("Invalid minimum packet length"));
 	}
 	var macAddress = parseInt(components[0]),
 	    msgId = parseInt(components[2]),
@@ -121,6 +121,7 @@ function handleData(data) {
 			return handleActionAckMessage(macAddress, payload);
 		default:
 			console.error(`Unknown Message type: ${msgId}`);
+			return Promise.reject(new Error(`Unknown Message type: ${msgId}`));
 	}
 }
 
@@ -216,6 +217,7 @@ function start(port) {
 };
 
 // export functions to make them public
+exports.handleData = handleData;
 exports.sendAction = sendAction;
 exports.isConnected = isConnected;
 exports.start = start;

--- a/server/gateway.js
+++ b/server/gateway.js
@@ -123,7 +123,7 @@ function handleHandshakeAckMessage(macAddress, payload) {
 function handleLostNodeMessage(macAddress, payload) {
 	var payloadValues = payload.split(',');
 	if (payloadValues.length < 1) {
-		return Promise.reject('invalid payload: ', payload);
+		return Promise.reject(new Error('invalid payload: ', payload));
 	}
 	var lostMacAddress = payloadValues[0];
 	return Outlet.find({mac_address: lostMacAddress}).exec()
@@ -132,8 +132,12 @@ function handleLostNodeMessage(macAddress, payload) {
 	    	throw new Error("Received LOST NODE message for unknown outlet " + lostMacAddress);
 	    }
 
+	    // Mark outlet as inactive in database.
 	    var outlet = outlets[0];
-	    // Send socket mesage to app announcing new node
+	    outlet.active = false;
+	    return outlet.save()
+	  }).then( outlet => {
+	  	// Send socket mesage to app announcing new node.
 	    return WS.sendLostNodeMessage(outlet._id, outlet.name);
 	  }).catch(console.error);
 }

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,7 @@
 var db      = require('./db');
 var gateway = require('./gateway');
+var http 		= require('http');
+var WS 			= require('./websockets');
 var app     = require('./app');
 
 // Connect to database
@@ -17,7 +19,15 @@ if (process.argv.length >= 3) {
 // Start serial port handler
 gateway.start(port);
 
+var server = http.createServer();
+
+// Connect websocket handler to server
+WS.init(server);
+
+// Connect app to web server
+server.on('request', app);
+
 // Start web server
-app.listen(3000, () => {
+server.listen(3000, () => {
     console.log('App Listening on Port 3000');
 });

--- a/server/models/Outlet.js
+++ b/server/models/Outlet.js
@@ -10,6 +10,7 @@ var outletSchema = new mongoose.Schema({
 	cur_humidity: Number,
 	cur_light: Number,
 	cur_power: Number,
+	active: {type: Boolean, default: true},
 	created: { type: Date, default: new Date() },
 	last_updated: { type: Date, default: new Date() }
 });

--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
     "express-validator": "^2.19.1",
     "mongoose": "^4.4.7",
     "morgan": "^1.7.0",
-    "serialport": "^2.0.6"
+    "serialport": "^2.0.6",
+    "ws": "^1.0.1"
   }
 }

--- a/server/websockets.js
+++ b/server/websockets.js
@@ -1,0 +1,66 @@
+var WebSocket = require('ws');
+var WebSocketServer = WebSocket.Server;
+
+// Global reference to websocket server.
+var wss = null;
+var hasConnection = false;
+
+function onConnect(socket) {
+	console.log('New socket connection');
+	hasConnection = true;
+
+	socket.on('message', (message) => {
+		console.log(`Message from client: ${message}`);
+	})
+}
+
+function init(server) {
+	wss = new WebSocketServer({server: server});
+
+	wss.on('connection', onConnect);
+
+	wss.on('error', (err) => {
+		console.error(err);
+	});
+
+	wss.on('close', (code, message) => {
+		console.log('socket connection closed');
+		hasConnection = false;
+	});
+}
+
+function isConnected() {
+	return wss && hasConnection;
+}
+
+function sendMessage(message) {
+	return new Promise((resolve, reject) => {
+		if (!isConnected()) {
+			return reject(new Error('Cannot send websocket message, client not connected'));
+		}
+		wss.clients.forEach(client => client.send(JSON.stringify(message)));
+		resolve(message);
+	}).catch(console.error);
+}
+
+function sendNewNodeMessage(outlet_id, name) {
+	return sendMessage({
+		type: 'NEWNODE',
+		outlet_id: outlet_id,
+		outlet_name: name
+	});
+}
+
+function sendLostNodeMessage(outlet_id, name) {
+	return sendMessage({
+		type: 'LOSTNODE',
+		outlet_id: outlet_id,
+		outlet_name: name
+	});
+}
+
+exports.init = init;
+exports.isConnected = isConnected;
+exports.sendNewNodeMessage = sendNewNodeMessage;
+exports.sendLostNodeMessage = sendLostNodeMessage;
+


### PR DESCRIPTION
- I assumed LOST_NODE messages have msgid=10
- When receiving a NEW_NODE message:
    - I create a new outlet in the database, and send a socket message to the app
    - When the app receives the message, it prompts the user for a new outlet name.
    - The app updates the server with the new outlet name, and refreshes the outlet list
- When receiving a LOST_NODE message:
    - I find the outlet in the database, and send a socket message to the app
    - When the app receives the message, it alerts the user fo the lost outlet.
    - TODO: decide whether to immediately remove the outlet from the database, or set an 'inactive' flag in the database...