### PR TITLE
Fixes #41 - triggers events as necessary when receiving sensor data

### DIFF
--- a/server/Gateway.js
+++ b/server/Gateway.js
@@ -1,8 +1,9 @@
-var Event      = require('./models/Event');
-var Outlet     = require('./models/Outlet');
-var SP         = require('serialport');
-var Watchdog   = require('./lib/Watchdog');
-var WS 				 = require('./websockets');
+var Event          = require('./models/Event');
+var EventScheduler = require('./lib/EventScheduler');
+var Outlet         = require('./models/Outlet');
+var SP             = require('serialport');
+var Watchdog       = require('./lib/Watchdog');
+var WS 				     = require('./websockets');
 
 // Constants
 const DEFAULT_SERIAL_PORT   = '/dev/ttty.usbserial-AM017Y3E';
@@ -30,7 +31,6 @@ var gWatchdogTimer = null;
 function isConnected() {
 	return gSerialPort && gSerialPort.isOpen();
 }
-
 
 /*
  * Saves the given sensor data into the database for the outlet with the given
@@ -79,8 +79,16 @@ function handleSensorDataMessage(macAddress, payload) {
       light = sensorValues[2],
       status = (sensorValues[3] === 0) ? 'OFF' : 'ON';
 
-  // TODO: Trigger events as necessary.
-  return saveSensorData(macAddress, power, temperature, light, status);
+  return saveSensorData(macAddress, power, temperature, light, status)
+  	.then(EventScheduler.triggerCommandsFromEvents)
+  	.then( commands => {
+  		console.log('Triggering commands: ', commands);
+  		// Send and action to the gateway for each command object given
+  		var commandPromises = commands.map(c => sendAction(c.destMacAddress, c.action));
+  		// Wait until all actions are sent.
+  		return Promise.all(commandPromises);
+  	})
+  	.catch(console.error);
 }
 
 /*
@@ -110,6 +118,7 @@ function handleActionAckMessage(macAddress, payload) {
 	    return outlet.save();
 		}).catch(console.error);
 }
+
 
 /*
  * Handle a Handshake Ack Message. Create a new outlet object in database,
@@ -211,7 +220,7 @@ function handleData(data) {
   console.log("[Gateway] >>>>>>>>>>", data);
 
   // Kick Watchdog timer.
-	gWatchdogTimer.kick();
+	if (gWatchdogTimer) gWatchdogTimer.kick();
 
 	/** Parse Packet **/
 	/** Packet format: "mac_addr:seq_num:msg_id:payload" **/

--- a/server/initial_data.js
+++ b/server/initial_data.js
@@ -32,9 +32,9 @@ var outlets = [
 ];
 
 var events = [
-	{ name: 'Event 1', input_threshold: 'above', input_value: 50 },
-	{ name: 'Event 2', input_threshold: 'above', input_value: 100 },
-	{ name: 'Event 3', input_threshold: 'below', input_value: 150 },
+	{ name: 'Event 1', input_threshold: 'above', input_value: 10, input: 'time' },
+	{ name: 'Event 2', input_threshold: 'below', input_value: 100, input: 'temperature' },
+	{ name: 'Event 3', input_threshold: 'above', input_value: 100, input: 'light' },
 ];
 
 function init() {

--- a/server/lib/EventScheduler.js
+++ b/server/lib/EventScheduler.js
@@ -1,0 +1,87 @@
+var Event      = require('../models/Event');
+var ObjectId   = require('mongoose').Types.ObjectId;
+var Outlet     = require('../models/Outlet');
+
+/**
+ * Given an event and an outlet (where the outlet is the event's input_outlet),
+ * determine if an action should be triggered.
+ * Compares the event's threshold value and direction with the outlet's
+ * appropriate sensor value.
+ * @return a non-null 'action' object if an action should be fired,
+ *   null otherwise.
+ */
+function shouldTriggerAction(event, outlet) {
+	var thresholdDirection = event.input_threshold;
+	var threshold = null;
+	var testValue = null;
+	if (event.input === 'time') {
+		// Compare the hours of the current time and the saved hour value.
+		testValue = (new Date()).getHours();
+		threshold = (new Date()).setHours(event.input_value);
+	} else if (event.input === 'temperature') {
+		testValue = outlet.cur_temperature;
+		threshold = event.input_value;
+	} else if (event.input === 'light') {
+		testValue = outlet.cur_light;
+		threshold = event.input_value;
+	} else {
+		// Shouldn't get here, but let's make temperature the default.
+		testValue = outlet.cur_temperature;
+		threshold = event.input_value;
+	}
+	// Create 'action' object if the test value is past the threshold
+	// in the desired direction.
+	if ( (thresholdDirection === 'above' && threshold <= testValue)
+			|| (thresholdDirection === 'below' && testValue < threshold)) {
+		return {
+			eventId: event._id,
+			outletId: event.output_outlet_id,
+			action: event.output_action
+		};
+	} else {
+		return null;
+	}
+}
+
+function triggerCommandsFromEvents(outlet) {
+	// Get all events that use this outlet as an input.
+	return Event.find({input_outlet_id: new ObjectId(outlet._id)}).exec()
+		.then( events => {
+			// Map each event to a possible action (if one should be triggered)
+			// TODO: how to handle duplicate/conflicting actions?
+			return events.map( event => shouldTriggerAction(event, outlet))
+				.filter( action => (action != null));
+		}).then( actions => {
+			// Map each action to a Promise<result>, where result is a
+			// (macAddress,action) object if a command should be sent, null otherwise
+			var actionPromises = actions.map( action => {
+				// Get the output outlet defined by the event.
+				// Convert it into an action if the outlet's state doesn't match the
+				// 	Event's action.
+				return Outlet.findById(new ObjectId(action.outletId)).exec()
+					.then( outlet => {
+						if (!outlet) throw new Error('Invalid output outlet id in event');
+
+						if (outlet && outlet.status != action.action) {
+							console.log(`Outlet ${outlet.mac_address} ${outlet.status}=>${action.action}`);
+
+							// Add the output outlet's mac address to the action object
+							return Object.assign(action, {
+								destMacAddress: outlet.mac_address,
+							});
+						} else {
+							// Outlet state already matches desired action, don't send command.
+							return null;
+						}
+					});
+			});
+			// Wait for all outlet queries to complete, then filter out any null objects.
+			return Promise.all(actionPromises)
+				.then(actions => {
+					return actions.filter( action => (action != null));
+				});
+		});
+}
+
+exports.shouldTriggerAction = shouldTriggerAction;
+exports.triggerCommandsFromEvents = triggerCommandsFromEvents;

--- a/server/models/Event.js
+++ b/server/models/Event.js
@@ -6,7 +6,7 @@ var eventSchema = new mongoose.Schema({
 	input_outlet_id: ObjectId,
 	input: {
 		type: String,
-		enum: ['time', 'light', 'humidity', 'temperature'],
+		enum: ['time', 'light', 'temperature'],
 		default: 'time'
 	},
 	input_threshold: { type: String, enum: ['above','below'], default: 'above' },


### PR DESCRIPTION
When receiving a data message from an outlet...
1) query all events that require the outlet as an input
2) compare the outlet's sensor data to the events' threshold, create 'action' objects if events need to be triggered
3) for each action object, query the necessary output outlet, and filter out any actions where the outlet's state doe not need to be changed
4) for each of the remaining action objects, send a command message to the gateway